### PR TITLE
Fix comment in tests

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -70,7 +70,7 @@ def test_agent_creation():
     memory = AgentMemory()
     calculator = CalculatorTool()
 
-    # Create agen
+    # Create agent
     agent = Agent(
         model=model,
         memory=memory,


### PR DESCRIPTION
## Summary
- fix typo in test comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6847fe81f5088327803129ff1fbdd6ae